### PR TITLE
Offer conversions via system resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ val scaledTextSize = textView.textSizeSp
 
 And convert between different units at will:
 ```kotlin
-val textSizePx = scaledTextSize.toPx(context)
+val textSizePx = scaledTextSize.toPx()
 ```
 
 ## License

--- a/app/src/main/java/drewhamilton/inlinedimens/demo/DemoActivity.kt
+++ b/app/src/main/java/drewhamilton/inlinedimens/demo/DemoActivity.kt
@@ -28,12 +28,12 @@ class DemoActivity : AppCompatActivity() {
 
         val screenWidth = screenSize.x
         val screenWidthPx: Int = screenWidth.value
-        val screenWidthDp: Int = screenWidth.toDp(this).toDpInt().value
+        val screenWidthDp: Int = screenWidth.toDp().toDpInt().value
         screenWidthView.text = getString(R.string.screenWidth, screenWidthPx, screenWidthDp)
 
         val screenHeight = screenSize.y
         val screenHeightPx: Int = screenHeight.value
-        val screenHeightDp: Int = screenHeight.toDp(this).toDpInt().value
+        val screenHeightDp: Int = screenHeight.toDp().toDpInt().value
         screenHeightView.text = getString(R.string.screenHeight, screenHeightPx, screenHeightDp)
 
         val textSizePx: Int = textSizeView.textSizePx.toPxInt().value

--- a/dimens/src/main/java/drewhamilton/inlinedimens/Dp.kt
+++ b/dimens/src/main/java/drewhamilton/inlinedimens/Dp.kt
@@ -17,6 +17,11 @@ fun Dp.toDpInt() = DpInt(value.toInt())
 
 //region toPx
 /**
+ * Convert [this] dp value to px based on the system [Resources]' display metrics.
+ */
+fun Dp.toPx() = toPx(Resources.getSystem())
+
+/**
  * Convert [this] dp value to px based on [context]'s display metrics.
  */
 fun Dp.toPx(context: Context) = toPx(context.resources)
@@ -38,6 +43,11 @@ internal fun Dp.toPx(density: Float) = Px(value * density)
 //endregion
 
 //region toSp
+/**
+ * Convert [this] dp value to sp based on the system [Resources]' display metrics.
+ */
+fun Dp.toSp() = toSp(Resources.getSystem())
+
 /**
  * Convert [this] dp value to sp based on [context]'s display metrics.
  */

--- a/dimens/src/main/java/drewhamilton/inlinedimens/DpInt.kt
+++ b/dimens/src/main/java/drewhamilton/inlinedimens/DpInt.kt
@@ -17,6 +17,11 @@ fun DpInt.toDpFloat() = Dp(value.toFloat())
 
 //region toPx
 /**
+ * Convert [this] dp value to px based on the system [Resources]' display metrics.
+ */
+fun DpInt.toPx() = toPx(Resources.getSystem())
+
+/**
  * Convert [this] dp value to px based on [context]'s display metrics.
  */
 fun DpInt.toPx(context: Context) = toPx(context.resources)
@@ -33,6 +38,11 @@ fun DpInt.toPx(displayMetrics: DisplayMetrics) = toDpFloat().toPx(displayMetrics
 //endregion
 
 //region toSp
+/**
+ * Convert [this] dp value to sp based on the system [Resources]' display metrics.
+ */
+fun DpInt.toSp() = toSp(Resources.getSystem())
+
 /**
  * Convert [this] dp value to sp based on [context]'s display metrics.
  */

--- a/dimens/src/main/java/drewhamilton/inlinedimens/Px.kt
+++ b/dimens/src/main/java/drewhamilton/inlinedimens/Px.kt
@@ -17,6 +17,11 @@ fun Px.toPxInt() = PxInt(value.toInt())
 
 //region toDp
 /**
+ * Convert [this] px value to dp based on the system [Resources]' display metrics.
+ */
+fun Px.toDp() = toDp(Resources.getSystem())
+
+/**
  * Convert [this] px value to dp based on [context]'s display metrics.
  */
 fun Px.toDp(context: Context) = toDp(context.resources)
@@ -38,6 +43,11 @@ internal fun Px.toDp(density: Float) = Dp(value / density)
 //endregion
 
 //region toSp
+/**
+ * Convert [this] px value to sp based on the system [Resources]' display metrics.
+ */
+fun Px.toSp() = toSp(Resources.getSystem())
+
 /**
  * Convert [this] px value to sp based on [context]'s display metrics.
  */

--- a/dimens/src/main/java/drewhamilton/inlinedimens/PxInt.kt
+++ b/dimens/src/main/java/drewhamilton/inlinedimens/PxInt.kt
@@ -17,6 +17,11 @@ fun PxInt.toPxFloat() = Px(value.toFloat())
 
 //region toDp
 /**
+ * Convert [this] px value to dp based on the system [Resources]' display metrics.
+ */
+fun PxInt.toDp() = toDp(Resources.getSystem())
+
+/**
  * Convert [this] px value to dp based on [context]'s display metrics.
  */
 fun PxInt.toDp(context: Context) = toDp(context.resources)
@@ -33,6 +38,11 @@ fun PxInt.toDp(displayMetrics: DisplayMetrics) = toPxFloat().toDp(displayMetrics
 //endregion
 
 //region toSp
+/**
+ * Convert [this] px value to sp based on the system [Resources]' display metrics.
+ */
+fun PxInt.toSp() = toSp(Resources.getSystem())
+
 /**
  * Convert [this] px value to sp based on [context]'s display metrics.
  */

--- a/dimens/src/main/java/drewhamilton/inlinedimens/Sp.kt
+++ b/dimens/src/main/java/drewhamilton/inlinedimens/Sp.kt
@@ -17,6 +17,11 @@ fun Sp.toSpInt() = SpInt(value.toInt())
 
 //region toPx
 /**
+ * Convert [this] sp value to px based on the system [Resources]' display metrics.
+ */
+fun Sp.toPx() = toPx(Resources.getSystem())
+
+/**
  * Convert [this] sp value to px based on [context]'s display metrics.
  */
 fun Sp.toPx(context: Context) = toPx(context.resources)
@@ -38,6 +43,11 @@ internal fun Sp.toPx(scaledDensity: Float) = Px(value * scaledDensity)
 //endregion
 
 //region toDp
+/**
+ * Convert [this] sp value to dp based on the system [Resources]' display metrics.
+ */
+fun Sp.toDp() = toDp(Resources.getSystem())
+
 /**
  * Convert [this] sp value to dp based on [context]'s display metrics.
  */

--- a/dimens/src/main/java/drewhamilton/inlinedimens/SpInt.kt
+++ b/dimens/src/main/java/drewhamilton/inlinedimens/SpInt.kt
@@ -17,6 +17,11 @@ fun SpInt.toSpFloat() = Sp(value.toFloat())
 
 //region toPx
 /**
+ * Convert [this] sp value to px based on the system [Resources]' display metrics.
+ */
+fun SpInt.toPx() = toPx(Resources.getSystem())
+
+/**
  * Convert [this] sp value to px based on [context]'s display metrics.
  */
 fun SpInt.toPx(context: Context) = toPx(context.resources)
@@ -33,6 +38,11 @@ fun SpInt.toPx(displayMetrics: DisplayMetrics) = toSpFloat().toPx(displayMetrics
 //endregion
 
 //region toDp
+/**
+ * Convert [this] sp value to dp based on the system [Resources]' display metrics.
+ */
+fun SpInt.toDp() = toDp(Resources.getSystem())
+
 /**
  * Convert [this] sp value to dp based on [context]'s display metrics.
  */

--- a/dimens/src/test/java/drewhamilton/inlinedimens/SystemResourcesTests.kt
+++ b/dimens/src/test/java/drewhamilton/inlinedimens/SystemResourcesTests.kt
@@ -1,0 +1,97 @@
+package drewhamilton.inlinedimens
+
+import android.content.res.Resources
+import com.google.common.truth.Truth
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Tests of functions that use [Resources.getSystem], provided by Robolectric.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(qualifiers = "xxhdpi")
+class SystemResourcesTests {
+
+    private val testInputFloat = 23.7f
+    private val testInputInt = 24
+
+    private val testPx = Px(testInputFloat)
+    private val testPxInt = PxInt(testInputInt)
+    private val testDp = Dp(testInputFloat)
+    private val testDpInt = DpInt(testInputInt)
+    private val testSp = Sp(testInputFloat)
+    private val testSpInt = SpInt(testInputInt)
+
+    //region Px
+    @Test fun `Px toDp() divides value by density from system DisplayMetrics`() {
+        Truth.assertThat(testPx.toDp().value)
+            .isEqualTo(testInputFloat / XXHDPI_DENSITY)
+    }
+
+    @Test fun `Px toSp() divides value by scaledDensity from system DisplayMetrics`() {
+        Truth.assertThat(testPx.toSp().value)
+            .isEqualTo(testInputFloat / XXHDPI_SCALED_DENSITY)
+    }
+
+    @Test fun `PxInt toDp() divides value by density from system DisplayMetrics`() {
+        Truth.assertThat(testPxInt.toDp().value)
+            .isEqualTo(testInputInt.toFloat() / XXHDPI_DENSITY)
+    }
+
+    @Test fun `PxInt toSp() divides value by scaledDensity from system DisplayMetrics`() {
+        Truth.assertThat(testPxInt.toSp().value)
+            .isEqualTo(testInputInt.toFloat() / XXHDPI_SCALED_DENSITY)
+    }
+    //endregion
+
+    //region Dp
+    @Test fun `Dp toPx() multiplies value by density from system DisplayMetrics`() {
+        Truth.assertThat(testDp.toPx().value)
+            .isEqualTo(testInputFloat * XXHDPI_DENSITY)
+    }
+
+    @Test fun `Dp toSp() multiplies value by density and divides by scaledDensity from system DisplayMetrics`() {
+        Truth.assertThat(testDp.toSp().value)
+            .isEqualTo(testInputFloat * XXHDPI_DENSITY / XXHDPI_SCALED_DENSITY)
+    }
+
+    @Test fun `DpInt toPx() multiplies value by density from system DisplayMetrics`() {
+        Truth.assertThat(testDpInt.toPx().value)
+            .isEqualTo(testInputInt.toFloat() * XXHDPI_DENSITY)
+    }
+
+    @Test fun `DpInt toSp() multiplies value by density and divides by scaledDensity from system DisplayMetrics`() {
+        Truth.assertThat(testDpInt.toSp().value)
+            .isEqualTo(testInputInt.toFloat() * XXHDPI_DENSITY / XXHDPI_SCALED_DENSITY)
+    }
+    //endregion
+
+    //region Sp
+    @Test fun `Sp toPx() multiplies value by scaledDensity from system DisplayMetrics`() {
+        Truth.assertThat(testSp.toPx().value)
+            .isEqualTo(testInputFloat * XXHDPI_SCALED_DENSITY)
+    }
+
+    @Test fun `Sp toDp() multiplies value by scaledDensity and divides by density from system DisplayMetrics`() {
+        Truth.assertThat(testSp.toDp().value)
+            .isEqualTo(testInputFloat * XXHDPI_SCALED_DENSITY / XXHDPI_DENSITY)
+    }
+
+    @Test fun `SpInt toPx() multiplies value by scaledDensity from system DisplayMetrics`() {
+        Truth.assertThat(testSpInt.toPx().value)
+            .isEqualTo(testInputInt.toFloat() * XXHDPI_SCALED_DENSITY)
+    }
+
+    @Test fun `SpInt toDp() multiplies value by scaledDensity and divides by density from system DisplayMetrics`() {
+        Truth.assertThat(testSpInt.toDp().value)
+            .isEqualTo(testInputInt.toFloat() * XXHDPI_SCALED_DENSITY / XXHDPI_DENSITY)
+    }
+    //endregion
+
+    private companion object {
+        private const val XXHDPI_DENSITY = 3f
+        private const val XXHDPI_SCALED_DENSITY = 3f
+    }
+}


### PR DESCRIPTION
As pointed out [by u/kroegerama on Reddit](https://www.reddit.com/r/androiddev/comments/cm0tg7/inlinedimens_android_dimension_types_as_inline/ew14tu3), `Resources.getSystem()` should have valid `DisplayMetrics` in the vast majority of cases. Using this allows Inline Dimens to offer parameter-free conversions functions.