### PR TITLE
Remove internal dimens interfaces.

### DIFF
--- a/dimens/src/main/java/drewhamilton/inlinedimens/Dimen.kt
+++ b/dimens/src/main/java/drewhamilton/inlinedimens/Dimen.kt
@@ -1,5 +1,0 @@
-package drewhamilton.inlinedimens
-
-internal interface Dimen {
-    val value: Float
-}

--- a/dimens/src/main/java/drewhamilton/inlinedimens/DimenInt.kt
+++ b/dimens/src/main/java/drewhamilton/inlinedimens/DimenInt.kt
@@ -1,5 +1,0 @@
-package drewhamilton.inlinedimens
-
-internal interface DimenInt {
-    val value: Int
-}

--- a/dimens/src/main/java/drewhamilton/inlinedimens/Dp.kt
+++ b/dimens/src/main/java/drewhamilton/inlinedimens/Dp.kt
@@ -8,7 +8,7 @@ import android.util.DisplayMetrics
 /**
  * The floating-point representation of dp dimens.
  */
-inline class Dp(override val value: Float) : Dimen
+inline class Dp(val value: Float)
 
 /**
  * Convert [this] to an integer dp dimen.

--- a/dimens/src/main/java/drewhamilton/inlinedimens/DpInt.kt
+++ b/dimens/src/main/java/drewhamilton/inlinedimens/DpInt.kt
@@ -8,7 +8,7 @@ import android.util.DisplayMetrics
 /**
  * The integer representation of dp dimens.
  */
-inline class DpInt(override val value: Int) : DimenInt
+inline class DpInt(val value: Int)
 
 /**
  * Convert [this] to a floating-point dp dimen.

--- a/dimens/src/main/java/drewhamilton/inlinedimens/Px.kt
+++ b/dimens/src/main/java/drewhamilton/inlinedimens/Px.kt
@@ -8,7 +8,7 @@ import android.util.DisplayMetrics
 /**
  * The floating-point representation of px dimens.
  */
-inline class Px(override val value: Float) : Dimen
+inline class Px(val value: Float)
 
 /**
  * Convert [this] to an integer px dimen.

--- a/dimens/src/main/java/drewhamilton/inlinedimens/PxInt.kt
+++ b/dimens/src/main/java/drewhamilton/inlinedimens/PxInt.kt
@@ -8,7 +8,7 @@ import android.util.DisplayMetrics
 /**
  * The integer representation of px dimens.
  */
-inline class PxInt(override val value: Int) : DimenInt
+inline class PxInt(val value: Int)
 
 /**
  * Convert [this] to a floating-point px dimen.

--- a/dimens/src/main/java/drewhamilton/inlinedimens/Sp.kt
+++ b/dimens/src/main/java/drewhamilton/inlinedimens/Sp.kt
@@ -8,7 +8,7 @@ import android.util.DisplayMetrics
 /**
  * The floating-point representation of sp dimens.
  */
-inline class Sp(override val value: Float) : Dimen
+inline class Sp(val value: Float)
 
 /**
  * Convert [this] to an integer sp dimen.

--- a/dimens/src/main/java/drewhamilton/inlinedimens/SpInt.kt
+++ b/dimens/src/main/java/drewhamilton/inlinedimens/SpInt.kt
@@ -8,7 +8,7 @@ import android.util.DisplayMetrics
 /**
  * The integer representation of sp dimens.
  */
-inline class SpInt(override val value: Int) : DimenInt
+inline class SpInt(val value: Int)
 
 /**
  * Convert [this] to a floating-point sp dimen.

--- a/dimens/src/main/java/drewhamilton/inlinedimens/widget/TextView.kt
+++ b/dimens/src/main/java/drewhamilton/inlinedimens/widget/TextView.kt
@@ -4,7 +4,6 @@ package drewhamilton.inlinedimens.widget
 import android.util.TypedValue
 import android.widget.TextView
 import androidx.core.widget.TextViewCompat
-import drewhamilton.inlinedimens.DimenInt
 import drewhamilton.inlinedimens.Dp
 import drewhamilton.inlinedimens.DpInt
 import drewhamilton.inlinedimens.Px
@@ -58,7 +57,12 @@ var TextView.textSizeSp: Sp
  * Throws [IllegalArgumentException] if any of the configuration params are invalid.
  */
 fun TextView.setAutoSizeTextTypeUniformWithConfiguration(minSize: PxInt, maxSize: PxInt, stepGranularity: PxInt) =
-    setAutoSizeTextTypeUniformWithConfiguration(minSize, maxSize, stepGranularity, TypedValue.COMPLEX_UNIT_PX)
+    TextViewCompat.setAutoSizeTextTypeUniformWithConfiguration(
+        this,
+        minSize.value, maxSize.value,
+        stepGranularity.value,
+        TypedValue.COMPLEX_UNIT_PX
+    )
 
 /**
  * Specify whether this widget should automatically scale the text to try to perfectly fit within the layout bounds. If
@@ -68,7 +72,12 @@ fun TextView.setAutoSizeTextTypeUniformWithConfiguration(minSize: PxInt, maxSize
  * Throws [IllegalArgumentException] if any of the configuration params are invalid.
  */
 fun TextView.setAutoSizeTextTypeUniformWithConfiguration(minSize: DpInt, maxSize: DpInt, stepGranularity: DpInt) =
-    setAutoSizeTextTypeUniformWithConfiguration(minSize, maxSize, stepGranularity, TypedValue.COMPLEX_UNIT_DIP)
+    TextViewCompat.setAutoSizeTextTypeUniformWithConfiguration(
+        this,
+        minSize.value, maxSize.value,
+        stepGranularity.value,
+        TypedValue.COMPLEX_UNIT_DIP
+    )
 
 /**
  * Specify whether this widget should automatically scale the text to try to perfectly fit within the layout bounds. If
@@ -78,19 +87,12 @@ fun TextView.setAutoSizeTextTypeUniformWithConfiguration(minSize: DpInt, maxSize
  * Throws [IllegalArgumentException] if any of the configuration params are invalid.
  */
 fun TextView.setAutoSizeTextTypeUniformWithConfiguration(minSize: SpInt, maxSize: SpInt, stepGranularity: SpInt) =
-    setAutoSizeTextTypeUniformWithConfiguration(minSize, maxSize, stepGranularity, TypedValue.COMPLEX_UNIT_SP)
-
-private fun TextView.setAutoSizeTextTypeUniformWithConfiguration(
-    minSize: DimenInt,
-    maxSize: DimenInt,
-    stepGranularity: DimenInt,
-    unit: Int
-) = TextViewCompat.setAutoSizeTextTypeUniformWithConfiguration(
-    this,
-    minSize.value, maxSize.value,
-    stepGranularity.value,
-    unit
-)
+    TextViewCompat.setAutoSizeTextTypeUniformWithConfiguration(
+        this,
+        minSize.value, maxSize.value,
+        stepGranularity.value,
+        TypedValue.COMPLEX_UNIT_SP
+    )
 //endregion
 
 //region setAutoSizeTextTypeUniformWithPresetSizes
@@ -102,7 +104,11 @@ private fun TextView.setAutoSizeTextTypeUniformWithConfiguration(
  * Throws [IllegalArgumentException] if all of the [presetSizes] are invalid.
  */
 fun TextView.setAutoSizeTextTypeUniformWithPresetSizes(presetSizes: Array<PxInt>) =
-    setAutoSizeTextTypeUniformWithPresetSizes(presetSizes, TypedValue.COMPLEX_UNIT_PX)
+    TextViewCompat.setAutoSizeTextTypeUniformWithPresetSizes(
+        this,
+        IntArray(presetSizes.size) { index -> presetSizes[index].value },
+        TypedValue.COMPLEX_UNIT_PX
+    )
 
 /**
  * Specify whether this widget should automatically scale the text to try to perfectly fit within the layout bounds. If
@@ -112,7 +118,11 @@ fun TextView.setAutoSizeTextTypeUniformWithPresetSizes(presetSizes: Array<PxInt>
  * Throws [IllegalArgumentException] if all of the [presetSizes] are invalid.
  */
 fun TextView.setAutoSizeTextTypeUniformWithPresetSizes(presetSizes: Array<DpInt>) =
-    setAutoSizeTextTypeUniformWithPresetSizes(presetSizes, TypedValue.COMPLEX_UNIT_DIP)
+    TextViewCompat.setAutoSizeTextTypeUniformWithPresetSizes(
+        this,
+        IntArray(presetSizes.size) { index -> presetSizes[index].value },
+        TypedValue.COMPLEX_UNIT_DIP
+    )
 
 /**
  * Specify whether this widget should automatically scale the text to try to perfectly fit within the layout bounds. If
@@ -122,10 +132,9 @@ fun TextView.setAutoSizeTextTypeUniformWithPresetSizes(presetSizes: Array<DpInt>
  * Throws [IllegalArgumentException] if all of the [presetSizes] are invalid.
  */
 fun TextView.setAutoSizeTextTypeUniformWithPresetSizes(presetSizes: Array<SpInt>) =
-    setAutoSizeTextTypeUniformWithPresetSizes(presetSizes, TypedValue.COMPLEX_UNIT_SP)
-
-private fun TextView.setAutoSizeTextTypeUniformWithPresetSizes(presetSizes: Array<out DimenInt>, unit: Int) =
-    TextViewCompat.setAutoSizeTextTypeUniformWithPresetSizes(this, presetSizes.values(), unit)
-
-private fun Array<out DimenInt>.values() = IntArray(size) { index -> this[index].value }
+    TextViewCompat.setAutoSizeTextTypeUniformWithPresetSizes(
+        this,
+        IntArray(presetSizes.size) { index -> presetSizes[index].value },
+        TypedValue.COMPLEX_UNIT_SP
+    )
 //endregion

--- a/dimens/src/test/java/drewhamilton/inlinedimens/widget/TextViewTest.kt
+++ b/dimens/src/test/java/drewhamilton/inlinedimens/widget/TextViewTest.kt
@@ -8,7 +8,6 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
 import com.nhaarman.mockitokotlin2.whenever
-import drewhamilton.inlinedimens.DimenInt
 import drewhamilton.inlinedimens.Dp
 import drewhamilton.inlinedimens.DpInt
 import drewhamilton.inlinedimens.Px
@@ -300,5 +299,7 @@ class TextViewTest {
         sdkIntField.setInt(null, sdkInt)
     }
 
-    private fun Array<out DimenInt>.values() = IntArray(size) { index -> this[index].value }
+    private fun Array<PxInt>.values() = IntArray(size) { index -> this[index].value }
+    private fun Array<DpInt>.values() = IntArray(size) { index -> this[index].value }
+    private fun Array<SpInt>.values() = IntArray(size) { index -> this[index].value }
 }


### PR DESCRIPTION
They caused unwanted boxing on the auto-size functions they were used in.

Fixes #4.