### PR TITLE
Conversions

### DIFF
--- a/app/src/main/java/dev/drewhamilton/inlinedimens/demo/DemoActivity.kt
+++ b/app/src/main/java/dev/drewhamilton/inlinedimens/demo/DemoActivity.kt
@@ -6,9 +6,7 @@ import androidx.appcompat.app.AppCompatActivity
 import dev.drewhamilton.inlinedimens.demo.databinding.DemoBinding
 import dev.drewhamilton.inlinedimens.graphics.PxPoint
 import dev.drewhamilton.inlinedimens.toDp
-import dev.drewhamilton.inlinedimens.toDpInt
-import dev.drewhamilton.inlinedimens.toPxInt
-import dev.drewhamilton.inlinedimens.toSpInt
+import dev.drewhamilton.inlinedimens.toSize
 import dev.drewhamilton.inlinedimens.view.getRealSize
 import dev.drewhamilton.inlinedimens.widget.textSizeDp
 import dev.drewhamilton.inlinedimens.widget.textSizePx
@@ -29,17 +27,17 @@ class DemoActivity : AppCompatActivity() {
 
         val screenWidth = screenSize.x
         val screenWidthPx: Int = screenWidth.value
-        val screenWidthDp: Int = screenWidth.toDp().toDpInt().value
+        val screenWidthDp: Int = screenWidth.toDp().toSize().value
         binding.screenWidthView.text = getString(R.string.screenWidth, screenWidthPx, screenWidthDp)
 
         val screenHeight = screenSize.y
         val screenHeightPx: Int = screenHeight.value
-        val screenHeightDp: Int = screenHeight.toDp().toDpInt().value
+        val screenHeightDp: Int = screenHeight.toDp().toSize().value
         binding.screenHeightView.text = getString(R.string.screenHeight, screenHeightPx, screenHeightDp)
 
-        val textSizePx: Int = binding.textSizeView.textSizePx.toPxInt().value
-        val textSizeDp: Int = binding.textSizeView.textSizeDp.toDpInt().value
-        val textSizeSp: Int = binding.textSizeView.textSizeSp.toSpInt().value
+        val textSizePx: Int = binding.textSizeView.textSizePx.toSize().value
+        val textSizeDp: Int = binding.textSizeView.textSizeDp.toSize().value
+        val textSizeSp: Int = binding.textSizeView.textSizeSp.toSize().value
         binding.textSizeView.text = getString(R.string.textSize, textSizePx, textSizeDp, textSizeSp)
     }
 

--- a/dimens/api/dimens.api
+++ b/dimens/api/dimens.api
@@ -52,6 +52,7 @@ public final class dev/drewhamilton/inlinedimens/DpIntKt {
 	public static final fun coerceAtLeast-0Bf2vQw (II)I
 	public static final fun coerceAtMost-0Bf2vQw (II)I
 	public static final fun coerceIn-pP1J9LM (III)I
+	public static final fun exact-JGqSb5Y (I)F
 	public static final fun getDp (I)I
 	public static final fun max-0Bf2vQw (II)I
 	public static final fun min-0Bf2vQw (II)I
@@ -79,10 +80,12 @@ public final class dev/drewhamilton/inlinedimens/DpKt {
 	public static final fun times-0bCDGXw (FF)F
 	public static final fun times-K46HDSY (IF)F
 	public static final fun toDpInt-TnY8d-w (F)I
+	public static final fun toOffset-TnY8d-w (F)I
 	public static final fun toPx-2n9RM2o (FLandroid/content/res/Resources;)F
 	public static final fun toPx-N4qJS8Q (FLandroid/content/Context;)F
 	public static final fun toPx-TnY8d-w (F)F
 	public static final fun toPx-wRUKyM8 (FLandroid/util/DisplayMetrics;)F
+	public static final fun toSize-TnY8d-w (F)I
 	public static final fun toSp-2n9RM2o (FLandroid/content/res/Resources;)F
 	public static final fun toSp-N4qJS8Q (FLandroid/content/Context;)F
 	public static final fun toSp-TnY8d-w (F)F
@@ -143,6 +146,7 @@ public final class dev/drewhamilton/inlinedimens/PxIntKt {
 	public static final fun coerceAtLeast-Oc1OQSs (II)I
 	public static final fun coerceAtMost-Oc1OQSs (II)I
 	public static final fun coerceIn-sY8d7LM (III)I
+	public static final fun exact-212CMWg (I)F
 	public static final fun getPx (I)I
 	public static final fun max-Oc1OQSs (II)I
 	public static final fun min-Oc1OQSs (II)I
@@ -173,7 +177,9 @@ public final class dev/drewhamilton/inlinedimens/PxKt {
 	public static final fun toDp-76TUCtA (FLandroid/content/res/Resources;)F
 	public static final fun toDp-VmHXAts (FLandroid/util/DisplayMetrics;)F
 	public static final fun toDp-_p0n2bw (FLandroid/content/Context;)F
+	public static final fun toOffset--OFvtLY (F)I
 	public static final fun toPxInt--OFvtLY (F)I
+	public static final fun toSize--OFvtLY (F)I
 	public static final fun toSp--OFvtLY (F)F
 	public static final fun toSp-76TUCtA (FLandroid/content/res/Resources;)F
 	public static final fun toSp-VmHXAts (FLandroid/util/DisplayMetrics;)F
@@ -234,6 +240,7 @@ public final class dev/drewhamilton/inlinedimens/SpIntKt {
 	public static final fun coerceAtLeast-heVpChI (II)I
 	public static final fun coerceAtMost-heVpChI (II)I
 	public static final fun coerceIn-M2-9BAQ (III)I
+	public static final fun exact-1syhwGc (I)F
 	public static final fun getSp (I)I
 	public static final fun max-heVpChI (II)I
 	public static final fun min-heVpChI (II)I
@@ -264,10 +271,12 @@ public final class dev/drewhamilton/inlinedimens/SpKt {
 	public static final fun toDp-EYuHYtE (F)F
 	public static final fun toDp-Y7tHPgs (FLandroid/content/Context;)F
 	public static final fun toDp-drTqqUg (FLandroid/util/DisplayMetrics;)F
+	public static final fun toOffset-EYuHYtE (F)I
 	public static final fun toPx-5IIdePQ (FLandroid/content/res/Resources;)F
 	public static final fun toPx-EYuHYtE (F)F
 	public static final fun toPx-Y7tHPgs (FLandroid/content/Context;)F
 	public static final fun toPx-drTqqUg (FLandroid/util/DisplayMetrics;)F
+	public static final fun toSize-EYuHYtE (F)I
 	public static final fun toSpInt-EYuHYtE (F)I
 }
 

--- a/dimens/src/main/java/dev/drewhamilton/inlinedimens/Dp.kt
+++ b/dimens/src/main/java/dev/drewhamilton/inlinedimens/Dp.kt
@@ -5,6 +5,7 @@ import android.content.res.Resources
 import android.util.DisplayMetrics
 import kotlin.math.max
 import kotlin.math.min
+import kotlin.math.roundToInt
 
 /**
  * The floating-point representation of dp dimens.
@@ -69,9 +70,34 @@ inline val Float.dp get() = Dp(this)
 inline val Double.dp get() = Dp(this.toFloat())
 
 /**
+ * Convert a floating-point dp dimen to an integer dp dimen by converting the value to a size.
+ *
+ * A size conversion involves rounding the base value and ensuring that a non-zero base value is at least one dp.
+ */
+fun Dp.toSize(): DpInt {
+    val rounded = value.roundToInt()
+    val size = when {
+        rounded != 0 -> rounded
+        value == 0f -> 0
+        value > 0f -> 1
+        else -> -1
+    }
+    return DpInt(size)
+}
+
+/**
+ * Convert a floating-point dp dimen to an integer dp dimen by simply truncating the base value.
+ */
+fun Dp.toOffset() = DpInt(value.toInt())
+
+/**
  * Convert a floating-point dp dimen to an integer dp dimen.
  */
-fun Dp.toDpInt() = DpInt(value.toInt())
+@Deprecated(
+    message = "Use toOffset to simply truncate the base value, or toSize to round to a size value",
+    replaceWith = ReplaceWith("toOffset()")
+)
+fun Dp.toDpInt() = toOffset()
 
 /**
  * Multiply a scalar by a [Dp].

--- a/dimens/src/main/java/dev/drewhamilton/inlinedimens/DpInt.kt
+++ b/dimens/src/main/java/dev/drewhamilton/inlinedimens/DpInt.kt
@@ -66,7 +66,16 @@ inline val Int.dp get() = DpInt(this)
 /**
  * Convert an integer dp dimen to a floating-point dp dimen.
  */
-fun DpInt.toDpFloat() = Dp(value.toFloat())
+fun DpInt.exact() = Dp(value.toFloat())
+
+/**
+ * Convert an integer dp dimen to a floating-point dp dimen.
+ */
+@Deprecated(
+    message = "Replaced with DpInt.exact()",
+    replaceWith = ReplaceWith("exact()")
+)
+fun DpInt.toDpFloat() = exact()
 
 /**
  * Multiply a scalar by a [DpInt].
@@ -132,7 +141,7 @@ fun DpInt.toPx(resources: Resources) = toPx(resources.displayMetrics)
 /**
  * Convert [this] dp value to px based on [displayMetrics].
  */
-fun DpInt.toPx(displayMetrics: DisplayMetrics) = toDpFloat().toPx(displayMetrics.density)
+fun DpInt.toPx(displayMetrics: DisplayMetrics) = exact().toPx(displayMetrics.density)
 //endregion
 
 //region toSp
@@ -154,7 +163,7 @@ fun DpInt.toSp(resources: Resources) = toSp(resources.displayMetrics)
 /**
  * Convert [this] dp value to sp based on [displayMetrics].
  */
-fun DpInt.toSp(displayMetrics: DisplayMetrics) = toDpFloat().toSp(
+fun DpInt.toSp(displayMetrics: DisplayMetrics) = exact().toSp(
     density = displayMetrics.density,
     scaledDensity = displayMetrics.scaledDensity
 )

--- a/dimens/src/main/java/dev/drewhamilton/inlinedimens/Px.kt
+++ b/dimens/src/main/java/dev/drewhamilton/inlinedimens/Px.kt
@@ -3,6 +3,7 @@ package dev.drewhamilton.inlinedimens
 import android.content.Context
 import android.content.res.Resources
 import android.util.DisplayMetrics
+import kotlin.math.roundToInt
 
 /**
  * The floating-point representation of px dimens.
@@ -67,9 +68,34 @@ inline val Float.px get() = Px(this)
 inline val Double.px get() = Px(this.toFloat())
 
 /**
+ * Convert a floating-point px dimen to an integer px dimen by converting the value to a size.
+ *
+ * A size conversion involves rounding the base value and ensuring that a non-zero base value is at least one px.
+ */
+fun Px.toSize(): PxInt {
+    val rounded = value.roundToInt()
+    val size = when {
+        rounded != 0 -> rounded
+        value == 0f -> 0
+        value > 0f -> 1
+        else -> -1
+    }
+    return PxInt(size)
+}
+
+/**
+ * Convert a floating-point px dimen to an integer px dimen by simply truncating the base value.
+ */
+fun Px.toOffset() = PxInt(value.toInt())
+
+/**
  * Convert [this] to an integer px dimen.
  */
-fun Px.toPxInt() = PxInt(value.toInt())
+@Deprecated(
+    message = "Use toOffset to simply truncate the base value, or toSize to round to a size value",
+    replaceWith = ReplaceWith("toOffset()")
+)
+fun Px.toPxInt() = toOffset()
 
 /**
  * Multiply a scalar by a [Px].

--- a/dimens/src/main/java/dev/drewhamilton/inlinedimens/PxInt.kt
+++ b/dimens/src/main/java/dev/drewhamilton/inlinedimens/PxInt.kt
@@ -62,9 +62,18 @@ inline class PxInt(val value: Int) : Comparable<PxInt> {
 inline val Int.px get() = PxInt(this)
 
 /**
- * Convert [this] to a floating-point px dimen.
+ * Convert an integer px dimen to a floating-point px dimen.
  */
-fun PxInt.toPxFloat() = Px(value.toFloat())
+fun PxInt.exact() = Px(value.toFloat())
+
+/**
+ * Convert an integer px dimen to a floating-point px dimen.
+ */
+@Deprecated(
+    message = "Replaced with PxInt.exact()",
+    replaceWith = ReplaceWith("exact()")
+)
+fun PxInt.toPxFloat() = exact()
 
 /**
  * Multiply a scalar by a [PxInt].

--- a/dimens/src/main/java/dev/drewhamilton/inlinedimens/Sp.kt
+++ b/dimens/src/main/java/dev/drewhamilton/inlinedimens/Sp.kt
@@ -3,6 +3,7 @@ package dev.drewhamilton.inlinedimens
 import android.content.Context
 import android.content.res.Resources
 import android.util.DisplayMetrics
+import kotlin.math.roundToInt
 
 /**
  * The floating-point representation of sp dimens.
@@ -67,9 +68,34 @@ inline val Float.sp: Sp get() = Sp(this)
 inline val Double.sp get() = Sp(this.toFloat())
 
 /**
+ * Convert a floating-point sp dimen to an integer sp dimen by converting the value to a size.
+ *
+ * A size conversion involves rounding the base value and ensuring that a non-zero base value is at least one sp.
+ */
+fun Sp.toSize(): SpInt {
+    val rounded = value.roundToInt()
+    val size = when {
+        rounded != 0 -> rounded
+        value == 0f -> 0
+        value > 0f -> 1
+        else -> -1
+    }
+    return SpInt(size)
+}
+
+/**
+ * Convert a floating-point sp dimen to an integer sp dimen by simply truncating the base value.
+ */
+fun Sp.toOffset() = SpInt(value.toInt())
+
+/**
  * Convert [this] to an integer sp dimen.
  */
-fun Sp.toSpInt() = SpInt(value.toInt())
+@Deprecated(
+    message = "Use toOffset to simply truncate the base value, or toSize to round to a size value",
+    replaceWith = ReplaceWith("toOffset()")
+)
+fun Sp.toSpInt() = toOffset()
 
 /**
  * Multiply a scalar by an [Sp].

--- a/dimens/src/main/java/dev/drewhamilton/inlinedimens/SpInt.kt
+++ b/dimens/src/main/java/dev/drewhamilton/inlinedimens/SpInt.kt
@@ -62,9 +62,18 @@ inline class SpInt(val value: Int) : Comparable<SpInt> {
 inline val Int.sp get() = SpInt(this)
 
 /**
- * Convert [this] to a floating-point sp dimen.
+ * Convert an integer sp dimen to a floating-point sp dimen.
  */
-fun SpInt.toSpFloat() = Sp(value.toFloat())
+fun SpInt.exact() = Sp(value.toFloat())
+
+/**
+ * Convert an integer sp dimen to a floating-point sp dimen.
+ */
+@Deprecated(
+    message = "Replaced with SpInt.exact()",
+    replaceWith = ReplaceWith("exact()")
+)
+fun SpInt.toSpFloat() = exact()
 
 /**
  * Multiply a scalar by an [SpInt].

--- a/dimens/src/test/java/dev/drewhamilton/inlinedimens/DpIntTest.kt
+++ b/dimens/src/test/java/dev/drewhamilton/inlinedimens/DpIntTest.kt
@@ -82,6 +82,11 @@ class DpIntTest {
     @Test fun `toString returns well-formatted unit`() =
         assertThat(testDpInt.toString()).isEqualTo("24dp")
 
+    @Test fun `exact converts via Int-toFloat`() =
+        assertThat(testDpInt.exact().value).isEqualTo(testInput.toFloat())
+
+    @Suppress("DEPRECATION")
+    @Deprecated("Testing deprecated function")
     @Test fun `toDpFloat converts via Int-toFloat`() =
         assertThat(testDpInt.toDpFloat().value).isEqualTo(testInput.toFloat())
 

--- a/dimens/src/test/java/dev/drewhamilton/inlinedimens/DpTest.kt
+++ b/dimens/src/test/java/dev/drewhamilton/inlinedimens/DpTest.kt
@@ -82,6 +82,23 @@ class DpTest {
     @Test fun `toString returns well-formatted unit`() =
         assertThat(testDp.toString()).isEqualTo("23.7dp")
 
+    @Test fun `toSize with normal value rounds value`() =
+        assertThat(testDp.toSize().value).isEqualTo(24)
+
+    @Test fun `toSize with low value resolves to one`() =
+        assertThat(0.3.dp.toSize().value).isEqualTo(1)
+
+    @Test fun `toSize with value zero resolves to zero`() =
+        assertThat(0f.dp.toSize().value).isEqualTo(0)
+
+    @Test fun `toSize with low negative value resolves to negative one`() =
+        assertThat(-0.1.dp.toSize().value).isEqualTo(-1)
+
+    @Test fun `toOffset converts via Float-toInt`() =
+        assertThat(testDp.toOffset().value).isEqualTo(testInput.toInt())
+
+    @Suppress("DEPRECATION")
+    @Deprecated("Testing deprecated function")
     @Test fun `toDpInt converts via Float-toInt`() =
         assertThat(testDp.toDpInt().value).isEqualTo(testInput.toInt())
 

--- a/dimens/src/test/java/dev/drewhamilton/inlinedimens/PxIntTest.kt
+++ b/dimens/src/test/java/dev/drewhamilton/inlinedimens/PxIntTest.kt
@@ -82,6 +82,11 @@ class PxIntTest {
     @Test fun `toString returns well-formatted unit`() =
         assertThat(testPxInt.toString()).isEqualTo("83487px")
 
+    @Test fun `exact converts via Int-toFloat`() =
+        assertThat(testPxInt.exact().value).isEqualTo(testInput.toFloat())
+
+    @Suppress("DEPRECATION")
+    @Deprecated("Testing deprecated function")
     @Test fun `toPxFloat converts via Int-toFloat`() {
         assertThat(testPxInt.toPxFloat().value)
             .isEqualTo(testInput.toFloat())

--- a/dimens/src/test/java/dev/drewhamilton/inlinedimens/PxTest.kt
+++ b/dimens/src/test/java/dev/drewhamilton/inlinedimens/PxTest.kt
@@ -82,6 +82,23 @@ class PxTest {
     @Test fun `toString returns well-formatted unit`() =
         assertThat(testPx.toString()).isEqualTo("98325.3px")
 
+    @Test fun `toSize with normal value rounds value`() =
+        assertThat(testPx.toSize().value).isEqualTo(98325)
+
+    @Test fun `toSize with low value resolves to one`() =
+        assertThat(0.3.px.toSize().value).isEqualTo(1)
+
+    @Test fun `toSize with value zero resolves to zero`() =
+        assertThat(0f.px.toSize().value).isEqualTo(0)
+
+    @Test fun `toSize with low negative value resolves to negative one`() =
+        assertThat(-0.1.px.toSize().value).isEqualTo(-1)
+
+    @Test fun `toOffset converts via Float-toInt`() =
+        assertThat(testPx.toOffset().value).isEqualTo(testInput.toInt())
+
+    @Suppress("DEPRECATION")
+    @Deprecated("Testing deprecated function")
     @Test fun `toPxInt converts via Float-toInt`() =
         assertThat(testPx.toPxInt().value).isEqualTo(testInput.toInt())
 

--- a/dimens/src/test/java/dev/drewhamilton/inlinedimens/SpIntTest.kt
+++ b/dimens/src/test/java/dev/drewhamilton/inlinedimens/SpIntTest.kt
@@ -82,6 +82,11 @@ class SpIntTest {
     @Test fun `toString returns well-formatted unit`() =
         assertThat(testSpInt.toString()).isEqualTo("932sp")
 
+    @Test fun `exact converts via Int-toFloat`() =
+        assertThat(testSpInt.exact().value).isEqualTo(testInput.toFloat())
+
+    @Suppress("DEPRECATION")
+    @Deprecated("Testing deprecated function")
     @Test fun `toDpFloat converts via Int-toFloat`() {
         assertThat(testSpInt.toSpFloat().value)
             .isEqualTo(testInput.toFloat())

--- a/dimens/src/test/java/dev/drewhamilton/inlinedimens/SpTest.kt
+++ b/dimens/src/test/java/dev/drewhamilton/inlinedimens/SpTest.kt
@@ -82,6 +82,23 @@ class SpTest {
     @Test fun `toString returns well-formatted unit`() =
         assertThat(testSp.toString()).isEqualTo("234.7sp")
 
+    @Test fun `toSize with normal value rounds value`() =
+        assertThat(testSp.toSize().value).isEqualTo(235)
+
+    @Test fun `toSize with low value resolves to one`() =
+        assertThat(0.3.sp.toSize().value).isEqualTo(1)
+
+    @Test fun `toSize with value zero resolves to zero`() =
+        assertThat(0f.sp.toSize().value).isEqualTo(0)
+
+    @Test fun `toSize with low negative value resolves to negative one`() =
+        assertThat(-0.1.sp.toSize().value).isEqualTo(-1)
+
+    @Test fun `toOffset converts via Float-toInt`() =
+        assertThat(testSp.toOffset().value).isEqualTo(testInput.toInt())
+
+    @Suppress("DEPRECATION")
+    @Deprecated("Testing deprecated function")
     @Test fun `toSpInt converts via Float-toInt`() =
         assertThat(testSp.toSpInt().value).isEqualTo(testInput.toInt())
 


### PR DESCRIPTION
Deprecate all `toDpFloat`, `toDpInt` conversions because the names are clumsy. Replace them with `exact` and `toOffset`, respectively.

Also introduce `toSize`, which performs size rounding similar to Android's `Resources.getDimensionPixelSize`.